### PR TITLE
Support *.pyi files and allow a TOML config file to be specified

### DIFF
--- a/ament_black/ament_black/main.py
+++ b/ament_black/ament_black/main.py
@@ -77,8 +77,8 @@ def main(argv=sys.argv[1:]):
 
     # invoke black
     cmd = [black_bin, "--diff"]
-    if args.config is not None:
-        cmd.extend(["--config", args.config])
+    if args.config_file is not None:
+        cmd.extend(["--config", args.config_file])
     cmd.extend(files)
 
     proc = subprocess.Popen(
@@ -107,8 +107,8 @@ def main(argv=sys.argv[1:]):
     # overwrite original with reformatted files
     if args.reformat and changed_files:
         cmd = [black_bin]
-        if args.config is not None:
-            cmd.extend(["--config", args.config])
+        if args.config_file is not None:
+            cmd.extend(["--config", args.config_file])
         cmd.extend(files)
         try:
             subprocess.check_call(cmd)

--- a/ament_black/ament_black/main.py
+++ b/ament_black/ament_black/main.py
@@ -53,6 +53,12 @@ def main(argv=sys.argv[1:]):
     parser.add_argument("--xunit-file", help="Generate a xunit compliant XML file")
     args = parser.parse_args(argv)
 
+    # if we have specified a config file, make sure it exists and abort if not
+    if args.config_file is not None and not os.path.exists(args.config_file):
+        print("Could not find config file '%s'" % args.config_file,
+              file=sys.stderr)
+        return 1
+
     if args.xunit_file:
         start_time = time.time()
 

--- a/ament_black/ament_black/main.py
+++ b/ament_black/ament_black/main.py
@@ -40,6 +40,12 @@ def main(argv=sys.argv[1:]):
         "in %s will be considered." % ", ".join(["'.%s'" % e for e in extensions]),
     )
     parser.add_argument(
+        '--config',
+        metavar='path',
+        default=None,
+        dest='config_file',
+        help='The config file')
+    parser.add_argument(
         "--reformat", action="store_true", help="Reformat the files in place"
     )
     # not using a file handle directly
@@ -71,6 +77,8 @@ def main(argv=sys.argv[1:]):
 
     # invoke black
     cmd = [black_bin, "--diff"]
+    if args.config is not None:
+        cmd.extend(["--config", args.config])
     cmd.extend(files)
 
     proc = subprocess.Popen(
@@ -99,6 +107,8 @@ def main(argv=sys.argv[1:]):
     # overwrite original with reformatted files
     if args.reformat and changed_files:
         cmd = [black_bin]
+        if args.config is not None:
+            cmd.extend(["--config", args.config])
         cmd.extend(files)
         try:
             subprocess.check_call(cmd)

--- a/ament_cmake_black/cmake/ament_black.cmake
+++ b/ament_cmake_black/cmake/ament_black.cmake
@@ -36,7 +36,9 @@ function(ament_black)
   set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.xunit.xml")
   set(cmd "${ament_black_BIN}" "--xunit-file" "${result_file}")
   list(APPEND cmd ${ARG_UNPARSED_ARGUMENTS})
-
+  if(ARG_CONFIG_FILE)
+    list(APPEND cmd "--config" "${ARG_CONFIG_FILE}")
+  endif()
   file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/ament_black")
   ament_add_test(
     "${ARG_TESTNAME}"

--- a/ament_cmake_black/cmake/ament_cmake_black_lint_hook.cmake
+++ b/ament_cmake_black/cmake/ament_cmake_black_lint_hook.cmake
@@ -14,6 +14,7 @@
 
 file(GLOB_RECURSE _source_files FOLLOW_SYMLINKS
   "*.py"
+  "*.pyi"
 )
 if(_source_files)
   message(STATUS "Added test 'black' to check Python code style")


### PR DESCRIPTION
This updates `ament_black` in two ways:

1. It lints `*.pyi` files in addition to `*.py` files.
2. It allows you to specify a `--config` file for your project.

The config file is a TOML file, which allows you to change things like target python version and default line length, More information can be found here: https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#configuration-via-a-file

Here's an example config file that applies stable checks for python3.8 and enforces a 100 character line limit:

```yaml
[tool.black]
line-length = 100
target-version = ['py38']
include = '\.pyi?$'
preview = false
```