### PR TITLE
Various fixes to pass all unit tests

### DIFF
--- a/ament_black/ament_black/__init__.py
+++ b/ament_black/ament_black/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2019 Picknik Robotics.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/ament_black/setup.py
+++ b/ament_black/setup.py
@@ -1,36 +1,50 @@
+# Copyright 2019 Picknik Robotics.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from setuptools import find_packages
 from setuptools import setup
 
-package_name = "ament_black"
+package_name = 'ament_black'
 
 setup(
     name=package_name,
-    version="0.0.1",
-    packages=find_packages(exclude=["test"]),
+    version='0.0.1',
+    packages=find_packages(exclude=['test']),
     data_files=[
-        ("share/" + package_name, ["package.xml"]),
-        ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
+        ('share/' + package_name, ['package.xml']),
+        ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
     ],
-    install_requires=["setuptools", "pyyaml"],
+    install_requires=['setuptools', 'pyyaml'],
     zip_safe=False,
-    author="Tyler Weaver",
-    author_email="tylerjw@gmail.com",
-    maintainer="Tyler Weaver",
-    maintainer_email="tylerjw@gmail.com",
-    url="https://github.com/tylerjw/ament_black",
-    download_url="https://github.com/tylerjw/ament_black/releases",
-    keywords=["ROS"],
+    author='Tyler Weaver',
+    author_email='tylerjw@gmail.com',
+    maintainer='Tyler Weaver',
+    maintainer_email='tylerjw@gmail.com',
+    url='https://github.com/tylerjw/ament_black',
+    download_url='https://github.com/tylerjw/ament_black/releases',
+    keywords=['ROS'],
     classifiers=[
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python",
-        "Topic :: Software Development",
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python',
+        'Topic :: Software Development',
     ],
-    description="Check Python code style using black.",
+    description='Check Python code style using black.',
     long_description="""\
 The ability to check code against style conventions using black
 and generate xUnit test result files.""",
-    license="Apache License, Version 2.0, BSD",
-    tests_require=["pytest"],
-    entry_points={"console_scripts": ["ament_black = ament_black.main:main"]},
+    license='Apache License, Version 2.0, BSD',
+    tests_require=['pytest'],
+    entry_points={'console_scripts': ['ament_black = ament_black.main:main']},
 )

--- a/ament_black/test/test_copyright.py
+++ b/ament_black/test/test_copyright.py
@@ -1,4 +1,4 @@
-# Copyright 2015 Open Source Robotics Foundation, Inc.
+# Copyright 2019 Picknik Robotics.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,5 +19,5 @@ import pytest
 @pytest.mark.copyright
 @pytest.mark.linter
 def test_copyright():
-    rc = main(argv=["ament_clang_format", "test"])
-    assert rc == 0, "Found errors"
+    rc = main(argv=['ament_black', 'test'])
+    assert rc == 0, 'Found errors'

--- a/ament_black/test/test_flake8.py
+++ b/ament_black/test/test_flake8.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Open Source Robotics Foundation, Inc.
+# Copyright 2019 Picknik Robotics.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,4 +20,4 @@ import pytest
 @pytest.mark.linter
 def test_flake8():
     rc = main(argv=[])
-    assert rc == 0, "Found code style errors / warnings"
+    assert rc == 0, 'Found code style errors / warnings'

--- a/ament_black/test/test_pep257.py
+++ b/ament_black/test/test_pep257.py
@@ -1,4 +1,4 @@
-# Copyright 2015 Open Source Robotics Foundation, Inc.
+# Copyright 2019 Picknik Robotics.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,5 +19,5 @@ import pytest
 @pytest.mark.linter
 @pytest.mark.pep257
 def test_pep257():
-    rc = main(argv=["ament_clang_format", "test"])
-    assert rc == 0, "Found docblock style errors"
+    rc = main(argv=['ament_black', 'test'])
+    assert rc == 0, 'Found docblock style errors'

--- a/ament_cmake_black/CMakeLists.txt
+++ b/ament_cmake_black/CMakeLists.txt
@@ -1,3 +1,17 @@
+# Copyright 2019 Picknik Robotics.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cmake_minimum_required(VERSION 3.5)
 
 project(ament_cmake_black NONE)

--- a/ament_cmake_black/cmake/ament_black.cmake
+++ b/ament_cmake_black/cmake/ament_black.cmake
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 #
 # Add a test to check the code for compliance with black.
 #

--- a/ament_cmake_black/cmake/ament_cmake_black_lint_hook.cmake
+++ b/ament_cmake_black/cmake/ament_cmake_black_lint_hook.cmake
@@ -1,4 +1,4 @@
-# Copyright 2015 Picknik Robotics
+# Copyright 2015 Picknik Robotics.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Right now we cant integrate `ament_black` into any other workspace because `colcon test` fails. The reason is down to some formatting inconsistencies in conjunction with the pep8 and pep257 tests. Also, there are some incorrect copyright headers in this repo, and two of the unit tests are actually testing clang-format, not black. This PR fixes all of the above.

Here are some instructions to show the unit tests passing.

```sh
$ source /opt/ros/rolling/setup.bash
$ mkdir -p ~/ament_black_ws/src
$ cd ~/ament_black_ws/src
$ git clone https://github.com/asymingt/ament_black.git 
$ git checkout asymingt/pass-unit-tests
$ cd ..
$ colcon build --symlink-install
$ colcon test --packages-select ament_cmake_black --event-handlers console_direct+
...
100% tests passed, 0 tests failed out of 2

Label Time Summary:
copyright     =   0.45 sec*proc (1 test)
lint_cmake    =   0.09 sec*proc (1 test)
linter        =   0.54 sec*proc (2 tests)

Total Test time (real) =   0.54 sec
Finished <<< ament_cmake_black [0.60s]          

Summary: 1 package finished [0.86s]

$ colcon test --packages-select ament_black --event-handlers console_direct+
...
collected 3 items                                                              

test/test_copyright.py .                                                 [ 33%]
test/test_flake8.py .                                                    [ 66%]
test/test_pep257.py .                                                    [100%]

- generated xml file: /usr/local/home/asymingt/development/ament_black_ws/build/ament_black/pytest.xml -
============================== 3 passed in 0.79s ===============================
Finished <<< ament_black [1.82s]          

Summary: 1 package finished [2.08s]
```

The majority of these changes are switching from double to single quotes, per the `flake8-quotes` extension. I know this is a contentious issue, so there might be a turnaround on this PR to revert these changes. The consequence would be that any uses who have `pip3 install falke8-quotes` will see unit test failures.