### PR TITLE
Add ament_cmake_black_CONFIG_FILE option.

### DIFF
--- a/ament_cmake_black/cmake/ament_black.cmake
+++ b/ament_cmake_black/cmake/ament_black.cmake
@@ -38,6 +38,8 @@ function(ament_black)
   list(APPEND cmd ${ARG_UNPARSED_ARGUMENTS})
   if(ARG_CONFIG_FILE)
     list(APPEND cmd "--config" "${ARG_CONFIG_FILE}")
+  elseif(DEFINED ament_cmake_black_CONFIG_FILE)
+    list(APPEND cmd "--config" "${ament_cmake_black_CONFIG_FILE}")
   endif()
   file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/ament_black")
   ament_add_test(


### PR DESCRIPTION
This pull request adds ament_cmake_black_CONFIG_FILE which mimics the options available in other ament lint packages like ament_cmake_flake8

e.g. https://github.com/ament/ament_lint/blob/humble/ament_cmake_flake8/cmake/ament_flake8.cmake#L54